### PR TITLE
Removed drupal/encrypt from composer dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,8 @@
   "name": "drupal/encrypt_kms",
   "description": "Provides an AWS KMS encryption method for Encrypt though the AWS SDK.",
   "type": "drupal-module",
-  "license": "GPL-2.0+",
   "homepage": "https://www.drupal.org/project/encrypt_kms",
   "require": {
-    "drupal/encrypt": "^1.0@alpha",
     "aws/aws-sdk-php": "~3.0"
   }
 }


### PR DESCRIPTION
Fixes this issue when trying to install via composer.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for drupal/encrypt_kms dev-8.x-1.x -> satisfiable by drupal/encrypt_kms[dev-8.x-1.x].
    - drupal/encrypt_kms dev-8.x-1.x requires drupal/encrypt ^1.0@alpha -> no matching package found.
```